### PR TITLE
Add Liquid Neural Network testbed

### DIFF
--- a/Liquid_NN/README.md
+++ b/Liquid_NN/README.md
@@ -1,0 +1,21 @@
+# Liquid Neural Network Testbed
+
+This directory contains a small, self‑contained implementation of a Liquid
+Neural Network layer written with NumPy.  It serves as a starting point for
+exploring liquid neural networks within the broader bio‑inspired SLAM
+project.
+
+## Files
+
+- `liquid_layer.py` – definition of the `LiquidLayer` class.
+- `demo.py` – simple script that instantiates a layer and runs it on random
+  data to verify it works.
+
+## Running the demo
+
+```bash
+python demo.py
+```
+
+The script will print the shape of the produced sequence and the final hidden
+state of the network.

--- a/Liquid_NN/demo.py
+++ b/Liquid_NN/demo.py
@@ -1,0 +1,20 @@
+"""Run a small demonstration of the :class:`LiquidLayer`."""
+
+import numpy as np
+from liquid_layer import LiquidLayer
+
+
+def main() -> None:
+    # Generate a random input sequence of length 100 with 3 features
+    inputs = np.random.randn(100, 3)
+
+    # Create and run the liquid layer
+    layer = LiquidLayer(input_size=3, hidden_size=5, dt=0.05, seed=0)
+    outputs = layer.forward(inputs)
+
+    print("Output shape:", outputs.shape)
+    print("Final state:", outputs[-1])
+
+
+if __name__ == "__main__":
+    main()

--- a/Liquid_NN/liquid_layer.py
+++ b/Liquid_NN/liquid_layer.py
@@ -1,0 +1,67 @@
+"""Simple implementation of a Liquid Neural Network layer using NumPy.
+
+This module provides the :class:`LiquidLayer`, a small liquid neural network
+layer that integrates a continuous-time differential equation using a simple
+Euler solver.  The implementation is intentionally lightweight and
+self-contained so it can act as a starting point for experiments.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+
+
+class LiquidLayer:
+    """A minimal Liquid Neural Network layer.
+
+    Parameters
+    ----------
+    input_size: int
+        Number of input features.
+    hidden_size: int
+        Number of neurons in the liquid layer.
+    dt: float, optional
+        Integration time step.
+    seed: int, optional
+        Random seed for reproducibility.
+    """
+
+    def __init__(self, input_size: int, hidden_size: int, dt: float = 0.01, *, seed: int | None = None) -> None:
+        rng = np.random.default_rng(seed)
+        self.input_size = input_size
+        self.hidden_size = hidden_size
+        self.dt = dt
+
+        # System matrices
+        self.A = rng.standard_normal((hidden_size, hidden_size)) * 0.1
+        self.W = rng.standard_normal((hidden_size, hidden_size)) * 0.1
+        self.U = rng.standard_normal((hidden_size, input_size)) * 0.1
+        self.bias = np.zeros(hidden_size)
+
+        # Initial state of the network
+        self.state = np.zeros(hidden_size)
+
+    def reset_state(self) -> None:
+        """Reset the internal state of the layer to zeros."""
+        self.state = np.zeros(self.hidden_size)
+
+    def forward(self, inputs: np.ndarray) -> np.ndarray:
+        """Propagate a sequence of inputs through the liquid layer.
+
+        Parameters
+        ----------
+        inputs: np.ndarray, shape (T, input_size)
+            Sequence of input vectors.
+
+        Returns
+        -------
+        np.ndarray, shape (T, hidden_size)
+            Sequence of hidden states produced by the network.
+        """
+
+        outputs = []
+        for u in inputs:
+            dx = -self.A @ self.state + np.tanh(self.W @ self.state + self.U @ u + self.bias)
+            self.state = self.state + self.dt * dx
+            outputs.append(self.state.copy())
+        return np.vstack(outputs)


### PR DESCRIPTION
## Summary
- add NumPy-based `LiquidLayer` with Euler integration for liquid neural network experiments
- include a demo script and README for quick testing

## Testing
- `python -m py_compile Liquid_NN/liquid_layer.py Liquid_NN/demo.py`
- `python Liquid_NN/demo.py`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689303da3d448326b4e465a2f23efdd8